### PR TITLE
Fix issue with sockets always being used.

### DIFF
--- a/craftingstore-core/src/main/java/net/craftingstore/Socket.java
+++ b/craftingstore-core/src/main/java/net/craftingstore/Socket.java
@@ -4,7 +4,7 @@ import com.google.gson.annotations.SerializedName;
 
 public class Socket {
 
-    private boolean socketEnabled;
+    private boolean socketAllowed;
     private Integer socketSupplier;
     private String socketConnectUrl;
     private String socketFallbackUrl;
@@ -14,7 +14,7 @@ public class Socket {
 
 
     public boolean getSocketAllowed() {
-        return socketEnabled;
+        return socketAllowed;
     }
 
     public String getSocketUrl() {


### PR DESCRIPTION
When setting up this plugin for use on our own server we found that regardless of the fact that we can't even enable sockets it was using them. After digging through the code and your API I noticed the /socket endpoint returns both`socketAllowed` which is false and `socketEnabled` which is true.

While I would normally be fine with getting access to a feature for free, the plugin also decides to slow down the normal interval check when sockets are enabled meaning that purchases made when a user is offline take up to 35+ minutes to process once they join the server which just doesn't work. I'm only opening a PR for this change as I don't know internally how you would want to handle a solution to this other problem. Hope this helps.